### PR TITLE
Update conscience templates for openio-sds-3.0.0.b1

### DIFF
--- a/manifests/conscience.pp
+++ b/manifests/conscience.pp
@@ -18,7 +18,17 @@ define openiosds::conscience (
   $service_update_policy                 = {'meta2'=>'KEEP|1|1|','sqlx'=>'KEEP|1|1|','rdir'=>'KEEP|1|1|user_is_a_service=1'},
   $pools                                 = {},
   $score_lock_at_first_register          = {},
-  $services_score_timeout                = {'meta0'=>'3600','meta1'=>'120','meta2'=>'120','rawx'=>'120','sqlx'=>'120','rdir'=>'120','redis'=>'120','oiofs'=>'120','account'=>'120','echo'=>'120'},
+  $services_score_timeout                = {'meta0'=>'3600','meta1'=>'120','meta2'=>'120','rawx'=>'120','sqlx'=>'120','rdir'=>'120','redis'=>'120','oiofs'=>'120','account'=>'120'},
+  $services_score_expr                   = {
+    'meta0'=>'root(2,((num stat.cpu)*(num stat.io)))',
+    'meta1'=>'((num stat.space)>=5) * root(3,((num stat.cpu)*(num stat.space)*(num stat.io)))',
+    'meta2'=>'((num stat.space)>=5) * root(3,((num stat.cpu)*(num stat.space)*(num stat.io)))',
+    'rawx'=>'(num tag.up) * ((num stat.space)>=5) * root(3,((num stat.cpu)*(num stat.space)*(num stat.io)))',
+    'sqlx'=>'((num stat.space)>=5) * root(3,((num stat.cpu)*(num stat.space)*(num stat.io)))',
+    'rdir'=>'(num tag.up) * (num stat.cpu) * ((num stat.space)>=2)',
+    'redis'=>'(num tag.up) * (num stat.cpu)',
+    'oiofs'=>'(num stat.cpu)',
+    'account'=>'(num tag.up) * (num stat.cpu)'},
   $automatic_open                        = true,
   $meta2_max_versions                    = '1',
   $min_workers                           = '2',
@@ -66,6 +76,7 @@ define openiosds::conscience (
   validate_integer($max_workers)
   validate_integer($score_timeout)
   validate_hash($services_score_timeout)
+  validate_hash($services_score_expr)
   validate_integer($param_option_events_max_pending)
   validate_integer($param_option_meta2_events_max_pending)
   validate_integer($param_option_meta1_events_max_pending)

--- a/templates/conscience.conf.erb
+++ b/templates/conscience.conf.erb
@@ -62,7 +62,7 @@ param_storage_conf=<%= scope['openiosds::sysconfdir'] %>/<%= @ns %>/<%= @type %>
 param_events=<%= scope['openiosds::sysconfdir'] %>/<%= @ns %>/<%= @type %>-<%= @num %>/conscience-<%= @num %>-events.conf
 
 # Service scoring and pools definitions
-param_service_conf=<%= scope['openiosds::sysconfdir'] %>/<%= @ns %>/<%= @type %>-<%= @num %>/conscience-<%= @num %>-services.conf
+param_service_conf=<%= scope['openiosds::sysconfdir'] %>/<%= @ns %>/<%= @type %>-<%= @num %>/conscience-<%= @num %>-service*.conf
 
 # For an easy transition, it is still possible to define
 # service score expression, variation, timeout and lock here.

--- a/templates/conscience.services.erb
+++ b/templates/conscience.services.erb
@@ -1,8 +1,10 @@
-[pools]
-# Pools for each service type
+# Service pools declarations
 # ----------------------------
 #
-# The value is a ';'-separated of targets.
+# Pools are automatically created if not defined in configuration,
+# according to storage policy or service update policy rules.
+#
+# "targets" is a ';'-separated list.
 # Each target is a ','-separated list of:
 # - the number of services to pick,
 # - the name of a slot where to pick the services,
@@ -10,34 +12,37 @@
 #   not enough in the previous slot
 # - and so on...
 #
-# Pool are automatically created if not defined in configuration.
+# "nearby_mode" is a boolean telling to find services close to each other
+# instead of far from each other.
+#
+#### power user options, don't set them unless you know what you are doing!
+# "mask" is a 64 bits hexadecimal mask used to check service distance.
+# It defaults to FFFFFFFFFFFF0000. It can also be specified as "/48".
+#
+# "mask_max_shift" is the maximum number of bits to shift the mask
+# to degrade it when distance requirement are not satisfiable.
+# It defaults to 16.
+#
+
 <% @pools.keys.sort.each do |key| -%>
-<%= key %>=<%= @pools[key] %>
+[pool:<%= key %>]
+targets=<%= @pools[key] %>
 <% end -%>
 
-[score_expr]
-meta0=root(2,((num stat.cpu)*(num stat.io)))
-meta1=((num stat.space)>=5) * root(3,((num stat.cpu)*(num stat.space)*(num stat.io)))
-meta2=((num stat.space)>=5) * root(3,((num stat.cpu)*(num stat.space)*(num stat.io)))
-rawx=(num tag.up) * ((num stat.space)>=5) * root(3,((num stat.cpu)*(num stat.space)*(num stat.io)))
-sqlx=((num stat.space)>=5) * root(3,((num stat.cpu)*(num stat.space)*(num stat.io)))
-account=(num tag.up) * (num stat.cpu)
-rdir=(num tag.up) * (num stat.cpu) * ((num stat.space)>=2)
-oiofs=(num stat.cpu)
-redis=(num tag.up) * (num stat.cpu)
-echo=(num stat.cpu)
-oiofs=(num stat.cpu)
 
-[score_timeout]
-# Defaults to 300s
-<% @services_score_timeout.keys.sort.each do |key| -%>
-<%= key %>=<%= @services_score_timeout[key] %>
+# Service types declarations
+# ---------------------------
+
+<% @services_score_expr.keys.sort.each do |key| -%>
+[type:<%= key -%>]
+score_expr=<%= @services_score_expr[key] %>
+<% if @services_score_timeout.has_key?(key) -%>
+score_timeout=<%= @services_score_timeout[key] %>
+<% end -%>
+<% if @score_lock_at_first_register.has_key?(key) -%>
+lock_at_first_register=<%= @score_lock_at_first_register[key] %>
 <% end -%>
 
-[score_variation_bound]
-# Defaults to 5s
-
-[score_lock_at_first_register]
-<% @score_lock_at_first_register.keys.sort.each do |key| -%>
-<%= key %>=<%= @score_lock_at_first_register[key] %>
 <% end -%>
+
+


### PR DESCRIPTION
I kept service pools and service types configurations in the same file but they can be split.
