### PR TITLE
Ensure rsyslog & logrotate are installed before openio-sds

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,6 +12,9 @@ class openiosds::install inherits openiosds {
     gid    => $openiosds::gid,
   }
 
+  # Pre-required packages
+  ensure_packages([$::openiosds::package_reqs_names],merge($::openiosds::params::package_install_options,{before => [File[$openiosds::globaldirs],File[$openiosds::sharedstatedir_global]]}))
+
   # Packages
   ensure_packages([$::openiosds::package_names],merge($::openiosds::params::package_install_options,{before => [File[$openiosds::globaldirs],File[$openiosds::sharedstatedir_global]]}))
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,7 +49,7 @@ class openiosds::params {
       $httpd_daemon            = '/usr/sbin/apache2'
       $httpd_moduledir         = "${libdir}/apache2/modules"
       $httpd_package_name      = ['openio-sds']
-      $package_names           = ['openio-sds','openio-sds-rsyslog','openio-sds-logrotate']
+      $package_names           = ['openio-sds']
       $redis_package_name      = 'redis-server'
       $redis_service_name      = 'redis-server'
       $package_swift_proxy     = 'swift-proxy'
@@ -76,7 +76,7 @@ class openiosds::params {
       $httpd_daemon              = '/usr/sbin/httpd'
       $httpd_moduledir           = "${libdir}/httpd/modules"
       $httpd_package_name        = ['openio-sds-mod-httpd']
-      $package_names             = ['openio-sds-server','openio-sds-rsyslog','openio-sds-logrotate']
+      $package_names             = ['openio-sds-server']
       $package_install_options   = {}
       $redis_package_name        = 'redis'
       $redis_service_name        = 'redis'
@@ -94,6 +94,7 @@ class openiosds::params {
         default: { $redis32 = false }
       }
     }
+    $package_reqs_names             = ['openio-sds-rsyslog','openio-sds-logrotate']
     default: { fail("osfamily ${::osfamily} not supported.") }
   }
   $memcached_package_name   = 'memcached'


### PR DESCRIPTION
Because we need the "syslog" user to be present when we do the chown in
the openio-sds postinst script on ubuntu.