### PR TITLE
add location to filter:swift3

### DIFF
--- a/templates/oioswift-proxy-server.conf.erb
+++ b/templates/oioswift-proxy-server.conf.erb
@@ -137,6 +137,7 @@ memcache_max_connections = <%= @memcache_max_connections %>
 [filter:swift3]
 use = egg:swift3#swift3
 force_swift_request_proxy_log = true
+location = <%= @region_name %>
 <% @middleware_swift3.each do |k,v| -%>
 <%= k %> = <%= v %>
 <% end -%>


### PR DESCRIPTION
When the region_name is not the default one (RegionOne), we should set the "location" for filter:swift3 too.