### PR TITLE
permit configuration of meta2 batch maxlen

### DIFF
--- a/manifests/namespace.pp
+++ b/manifests/namespace.pp
@@ -49,6 +49,7 @@ define openiosds::namespace (
   $client_down_cache_avoid = undef,
   $ns_worm = undef,
   $meta2_max_versions = undef,
+  $meta2_batch_maxlen = undef,
   $ns_service_update_policy     = {
     'meta2' => 'KEEP|3|1|',
     'sqlx'  => 'KEEP|1|1|',
@@ -114,6 +115,7 @@ define openiosds::namespace (
   if $server_periodic_decache_max_bases { validate_string($server_periodic_decache_max_bases) }
   if $server_periodic_decache_period { validate_string($server_periodic_decache_period) }
   if $meta2_max_versions { validate_string($meta2_max_versions) }
+  if $meta2_batch_maxlen { validate_integer($meta2_max_versions, 100000, 1) }
 
   if $openiosds::action == 'create' {
     # Path

--- a/templates/sds-ns.conf.erb
+++ b/templates/sds-ns.conf.erb
@@ -106,6 +106,8 @@ conscience=<%= @conscience_url %>
 <%end -%>
 <% if @meta2_max_versions %>meta2.max_versions = <%= @meta2_max_versions %>
 <%end -%>
+<% if @meta2_batch_maxlen %>meta2.batch.maxlen = <%= @meta2_batch_maxlen %>
+<%end -%>
 <% if @server_periodic_decache_max_bases%>server.periodic_decache.max_bases = <%= @server_periodic_decache_max_bases %>
 <%end -%>
 <% if @server_periodic_decache_period%>server.periodic_decache.period = <%= @server_periodic_decache_period %>


### PR DESCRIPTION
With this patch + adding `max_bucket_listing` in `middleware_swift3` section we can page with more than 1000.

to test : `aws ls --page-size 2000 --recursive s3://testbucket`