### PR TITLE
Allow to set resolver cache TTL

### DIFF
--- a/manifests/namespace.pp
+++ b/manifests/namespace.pp
@@ -41,6 +41,8 @@ define openiosds::namespace (
   $gridd_timeout_connect_common = undef,
   $resolver_cache_srv_max_default = undef,
   $resolver_cache_csm0_max_default = undef,
+  $resolver_cache_srv_ttl_default = undef,
+  $resolver_cache_csm0_ttl_default = undef,
   $sqliterepo_cache_ttl_cool = undef,
   $sqliterepo_cache_ttl_hot = undef,
   $client_errors_cache_enabled = undef,
@@ -105,6 +107,8 @@ define openiosds::namespace (
   if $gridd_timeout_connect_common { validate_string($gridd_timeout_connect_common) }
   if $resolver_cache_srv_max_default { validate_string($resolver_cache_srv_max_default) }
   if $resolver_cache_csm0_max_default { validate_string($resolver_cache_csm0_max_default) }
+  if $resolver_cache_srv_ttl_default { validate_string($resolver_cache_srv_ttl_default) }
+  if $resolver_cache_csm0_ttl_default { validate_string($resolver_cache_csm0_ttl_default) }
   if $sqliterepo_cache_ttl_cool { validate_string($sqliterepo_cache_ttl_cool) }
   if $sqliterepo_cache_ttl_hot { validate_string($sqliterepo_cache_ttl_hot) }
   if $client_errors_cache_enabled { validate_string($client_errors_cache_enabled) }

--- a/templates/sds-ns.conf.erb
+++ b/templates/sds-ns.conf.erb
@@ -56,6 +56,10 @@ conscience=<%= @conscience_url %>
 <%end -%>
 <% if @resolver_cache_csm0_max_default %>resolver.cache.csm0.max.default = <%= @resolver_cache_csm0_max_default %>
 <%end -%>
+<% if @resolver_cache_srv_ttl_default %>resolver.cache.srv.ttl.default = <%= @resolver_cache_srv_ttl_default %>
+<%end -%>
+<% if @resolver_cache_csm0_ttl_default %>resolver.cache.csm0.ttl.default = <%= @resolver_cache_csm0_ttl_default %>
+<%end -%>
 <% if @server_udp_queue_ttl %>server.udp_queue.ttl = <%= @server_udp_queue_ttl %>
 <%end -%>
 <% if @server_udp_queue_max %>server.udp_queue.max = <%= @server_udp_queue_max %>


### PR DESCRIPTION
The cache keeps service entries forever. In some cases we would like to make them expire.

`resolver_cache_csm0_ttl_default` (meta0 and meta1 addresses) and `resolver_cache_srv_ttl_default` (meta2 addresses) new options are now available.
- 0 -> keep entries forever;
- N -> keep entries N microseconds.